### PR TITLE
Remove deprecated React.__spread method usage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ module.exports = React.createClass({
         props.className = props.className || ''
         props.className += ' loadmask'
 
-        return React.createElement("div", React.__spread({},  props), 
+        return React.createElement("div", props, 
             React.createElement(Loader, {size: props.size})
         )
     },


### PR DESCRIPTION
React.__spread is deprecated in React v15 and was never intended to be used by external sources. It is also unnecessary in this case as its usage results in a superfluous object clone.
